### PR TITLE
pelletier-construction-group-nextjs-8-15-create-issue-pull-request-templates

### DIFF
--- a/.github/issue_template/bug_report.md
+++ b/.github/issue_template/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**\
+A clear and concise description of what the bug is.
+
+**To Reproduce**\
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**\
+A clear and concise description of what you expected to happen.
+
+**Screenshots**\
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**\
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**\
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Is this issue related to any other issues?**\
+If so, please add "This issue relates to issue #< related issue >." to link the issues together.
+
+**Additional context**\
+Add any other context about the problem here.
+
+**Story Points**\
+Please estimate amount of story points. Each story point is defined as 30 minutes.

--- a/.github/issue_template/config.yml
+++ b/.github/issue_template/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/issue_template/feature_request.md
+++ b/.github/issue_template/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Make sure the first line is formatted as follows.**\
+As a < role >, I will want to < task >.
+
+**Is your feature request related to a problem? Please describe.**\
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**\
+A clear and concise description of what you want to happen.
+
+**Include link(s) to relevant tutorial(s)**\
+Please include at least one link to a relevant tutorial for the issue to give developers a starting point. 
+
+**Describe alternatives you've considered**\
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Is this issue related to any other issues?**\
+If so, please add "This issue relates to issue #< related issue >." to link the issues together.
+
+**Additional context**\
+Add any other context or screenshots about the feature request here.
+
+**Story Points**\
+Please estimate amount of story points. Each story point is defined as 30 minutes.

--- a/.github/issue_template/issue.md
+++ b/.github/issue_template/issue.md
@@ -1,0 +1,23 @@
+---
+name: Issue
+about: Create an issue.
+title: '[Title of Issue]'
+labels: ''
+assignees: ''
+
+---
+
+This is an issue!
+
+1. Please use the following format for the title:
+
+<Title of Issue>
+
+2. Please fill out this description with the following:
+
+- Any additional information you feel is necessary.
+- Screenshots/gifs/videos/diagrams/other visual aids.
+
+3. Remember to:
+
+- Add assignees, labels and projects in the menu at the bottom or to the right of the screen.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+This is a pull request!
+
+Please use the following format for the title:
+< repo > _ < sprint > _ < issue > _ < pr or issue name >
+
+Please fill out this description with the following:
+Resolves <issue #>
+Description of what this pull request is for.
+Additional information to help others that are testing.
+Screenshots/gifs/videos/diagrams/other visual aids.
+Remember to:
+Add reviewers, assignees and labels in the menu on the right. --->
+Enable auto-merge (squash) at the bottom of the page.


### PR DESCRIPTION
resolves #15 

This PR adds issue and pull request templates to the .github folder on this repo. This will allow for the following:
- Ability to choose a template when creating an issue that will guide us through the process of creating the issue. 
- Automatically apply a standard template to any pull request that is opened on this repo.