### PR TITLE
pelletier-construction-group-nextjs_9_32_home-page-details

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,18 +9,18 @@ export default function Home() {
     <Stack>
       <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ paddingTop: "120px", backgroundColor:"white" }}>
         <Typography component="h1" variant="h4" sx={{ pb: 4 }}>
-          Seattle's Premier DADU Specialists
+          Seattle&apos;s Premier DADU Specialists
         </Typography>
         <Typography>
           <Link href="tel:+19078417274" passHref>
-            <Box component="a" sx={{ color: "inherit", textDecoration: "none", '&:hover': { textDecoration: 'underline' } }}>
+            <Box component="a" sx={{ color: "inherit", textDecoration: "none", "&:hover": { textDecoration: "underline" } }}>
               (907) 841-7274
             </Box>
           </Link>
         </Typography>
         <Typography>
           <Link href="mailto:ryan@pelletier.construction" passHref>
-            <Box component="a" sx={{ color: "inherit", textDecoration: "none", '&:hover': { textDecoration: 'underline' } }}>
+            <Box component="a" sx={{ color: "inherit", textDecoration: "none", "&:hover": { textDecoration: "underline" } }}>
               ryan@pelletier.construction
             </Box>
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,36 @@
-import {Box, Typography} from "@mui/material";
+import {Box, Button, Stack, Typography} from "@mui/material";
+import Footer from '../components/Footer';
+import Link from "next/link";
 
 export default function Home() {
 
   return (
-      <Box sx={ { paddingTop: "55px"}}>
-        <Typography>
-          Placeholder text for the homepage.
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: "100vh", backgroundColor: "white", color: "black" }}>
+    <Stack>
+      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ paddingTop: "120px", backgroundColor:"white" }}>
+        <Typography component="h1" variant="h4" sx={{ pb: 4 }}>
+          Seattle's Premier DADU Specialists
         </Typography>
+        <Typography>
+          <Link href="tel:+19078417274" passHref>
+            <Box component="a" sx={{ color: "inherit", textDecoration: "none", '&:hover': { textDecoration: 'underline' } }}>
+              (907) 841-7274
+            </Box>
+          </Link>
+        </Typography>
+        <Typography>
+          <Link href="mailto:ryan@pelletier.construction" passHref>
+            <Box component="a" sx={{ color: "inherit", textDecoration: "none", '&:hover': { textDecoration: 'underline' } }}>
+              ryan@pelletier.construction
+            </Box>
+          </Link>
+        </Typography>
+        <Button variant="contained" color="primary" href="/contact" sx={{ mt: 3, fontSize: "1.2rem", width: "200px", height: "50px" }}>
+          Contact Us
+        </Button>
       </Box>
+    </Stack>    
+    <Footer />
+    </Box>
   )
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Box, Typography, Grid, Stack, IconButton } from '@mui/material';
+import FacebookIcon from '@mui/icons-material/Facebook';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import PhoneIcon from '@mui/icons-material/Phone';
+import EmailIcon from '@mui/icons-material/Email';
+import Link from 'next/link';
+
+const Footer: React.FC = () => {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        backgroundColor: "black",
+        color: "white",
+        py: 2,
+        px: 2,
+        mt: "auto",
+        textAlign: "center"
+      }}
+    >
+      <Stack direction="column" width="30%" margin="auto" justifyContent="center">
+        <Box display="flex" alignItems="center" justifyContent="center">
+          <Link href="http://www.facebook.com/pelletierconstruction/" passHref
+          target="_blank" 
+          rel="noopener noreferrer" 
+          color="inherit" 
+          >
+            <IconButton aria-label="Facebook" sx={{ color: "inherit" }}>
+                <FacebookIcon />
+            </IconButton>
+          </Link>
+        </Box>
+        <Box display="flex" alignItems="center" justifyContent="center">
+          <Link href="https://www.google.com/maps/search/?api=1&query=1150%20North%2084th%20Street%2C%20Seattle%2C%20WA%2098103" passHref
+            target="_blank" 
+            rel="noopener noreferrer" 
+            color="inherit" 
+            >
+                <IconButton aria-label="Map" sx={{ color: "inherit" }}>
+                    <LocationOnIcon />
+                </IconButton>
+                1150 North 84th Street, Seattle, WA 98103
+          </Link>
+        </Box>
+        <Box display="flex" alignItems="center" justifyContent="center">
+          <Link href="tel:+19078417274" passHref color="inherit">
+            <IconButton aria-label="Phone" sx={{ color: "inherit" }}>
+                <PhoneIcon />
+            </IconButton>
+            (907) 841-7274
+          </Link>
+        </Box>
+        <Box display="flex" alignItems="center" justifyContent="center">
+          <Link href="mailto:ryan@pelletier.construction" passHref color="inherit">
+            <IconButton aria-label="Email" color="inherit">
+                <EmailIcon />
+            </IconButton>
+            ryan@pelletier.construction
+          </Link>
+        </Box>
+      </Stack>
+    </Box>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
Resolves #32

This PR creates a Home page and footer with the necessary details for Pelletier Construction Group, based off of the github.io site. The Contact Us buttons directs the user to the Contact page.

![Screenshot 2024-07-10 233003](https://github.com/PelletierConstructionGroup/pelletier-construction-group-nextjs/assets/77607212/98584007-9074-4f8f-9833-558f283eb2d6)
![Screenshot 2024-07-10 233021](https://github.com/PelletierConstructionGroup/pelletier-construction-group-nextjs/assets/77607212/29b6e10a-3005-4945-b2f4-b01d61b459e5)
