### PR TITLE
pelletier-construction-group-nextjs_9_39_placeholder-pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Stack, Typography} from "@mui/material";
+import {Box, Stack, Typography} from "@mui/material";
 import Footer from "@/components/Footer";
 import Link from "next/link";
 
@@ -7,9 +7,12 @@ export default function Home() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: "100vh", maximumWidth: "100vw", backgroundColor: "white", color: "black" }}>
     <Stack>
-      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ paddingTop: "120px", width: "100%", backgroundColor:"white" }}>
+      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ width: "100%", paddingTop: "120px", backgroundColor:"white" }}>
       <Typography component="h1" variant="h4" sx={{ pb: 4 }}>
-          Estimates
+          About Us
+        </Typography>
+        <Typography component="h1" variant="h5" sx={{ pb: 4 }}>
+          Dedicated to Our Clients
         </Typography>
         <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
           <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -7,10 +7,27 @@ export default function Home() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: "100vh", maximumWidth: "100vw", backgroundColor: "white", color: "black" }}>
     <Stack>
-      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ paddingTop: "120px", width: "100%", backgroundColor:"white" }}>
+      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ width: "100%", paddingTop: "120px", backgroundColor:"white" }}>
       <Typography component="h1" variant="h4" sx={{ pb: 4 }}>
-          Estimates
+          Contact Us
         </Typography>
+        <Typography>
+          <Link href="tel:+19078417274" passHref>
+            <Box component="a" sx={{ color: "inherit", textDecoration: "none", "&:hover": { textDecoration: "underline" } }}>
+              (907) 841-7274
+            </Box>
+          </Link>
+        </Typography>
+        <Typography>
+          <Link href="mailto:ryan@pelletier.construction" passHref>
+            <Box component="a" sx={{ color: "inherit", textDecoration: "none", "&:hover": { textDecoration: "underline" } }}>
+              ryan@pelletier.construction
+            </Box>
+          </Link>
+        </Typography>
+        <Button variant="contained" color="primary" href="/contact" sx={{ mt: 3, mb: 4, fontSize: "1.2rem", width: "200px", height: "50px" }}>
+          Call Now
+        </Button>
         <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
           <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>
             Get in Touch

--- a/app/projects-page/page.tsx
+++ b/app/projects-page/page.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Stack, Typography} from "@mui/material";
+import {Box, Stack, Typography} from "@mui/material";
 import Footer from "@/components/Footer";
 import Link from "next/link";
 
@@ -7,9 +7,9 @@ export default function Home() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: "100vh", maximumWidth: "100vw", backgroundColor: "white", color: "black" }}>
     <Stack>
-      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ paddingTop: "120px", width: "100%", backgroundColor:"white" }}>
+      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ width: "100%", paddingTop: "120px", backgroundColor:"white" }}>
       <Typography component="h1" variant="h4" sx={{ pb: 4 }}>
-          Estimates
+          Our Builds
         </Typography>
         <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
           <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Stack, Typography} from "@mui/material";
+import {Box, Stack, Typography} from "@mui/material";
 import Footer from "@/components/Footer";
 import Link from "next/link";
 
@@ -7,9 +7,9 @@ export default function Home() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: "100vh", maximumWidth: "100vw", backgroundColor: "white", color: "black" }}>
     <Stack>
-      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ paddingTop: "120px", width: "100%", backgroundColor:"white" }}>
+      <Box margin="auto" textAlign={"center"} justifyContent={"center"} sx={{ width: "100%", paddingTop: "120px", backgroundColor:"white" }}>
       <Typography component="h1" variant="h4" sx={{ pb: 4 }}>
-          Estimates
+          Kind Words from Our Collaborators
         </Typography>
         <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
           <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>


### PR DESCRIPTION
Resolves #39

I picked up these Sprint 9 issues because they seem to have been abandoned.

This PR creates placeholder pages for the Projects, About, Testimonials, and Contact pages by adding their appropriate headers and a footer. I also added the Google form to all pages where they should be (according to Github.io site).

Projects page:
![Screenshot 2024-08-01 234322](https://github.com/user-attachments/assets/6908c69e-5eb3-4cf3-90d9-fa7fd0f72ff7)
![Screenshot 2024-08-01 234432](https://github.com/user-attachments/assets/f979ae2b-fc9c-48e4-9a82-fdbe711dc3c9)
Estimates:
![Screenshot 2024-08-01 234729](https://github.com/user-attachments/assets/9eff1e85-feca-4a8b-936d-f32d2ed63107)
About page:
![Screenshot 2024-08-01 234741](https://github.com/user-attachments/assets/ca746afb-0909-46c8-9212-cd89c9cd60a9)
Testimonials page:
![Screenshot 2024-08-01 234755](https://github.com/user-attachments/assets/fddaae1c-ca98-4ea6-8634-bc7b4e0cc300)
Contact page:
![Screenshot 2024-08-01 234807](https://github.com/user-attachments/assets/ccdb2bab-a152-46fd-94a9-d2da1d9b5d10)
