### PR TITLE
pcg_12_42_about_page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,8 @@
 import {Box, Stack, Typography} from "@mui/material";
 import Footer from "@/components/Footer";
 import Link from "next/link";
+import Image from 'next/image';
+
 
 export default function Home() {
 
@@ -14,6 +16,43 @@ export default function Home() {
         <Typography component="h1" variant="h5" sx={{ pb: 4 }}>
           Dedicated to Our Clients
         </Typography>
+          <Box
+            margin="auto"
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "flex-start", 
+              alignItems: "flex-start",
+              maxWidth: "80%", 
+              gap: 11, 
+              mb: 4,
+            }}
+          >
+            <Box sx={{ flexShrink: 0, pl: 2 }}> 
+              <Image
+                src="/images/Logo small.png"
+                alt="Pelletier Construction Group Logo"
+                width={100}
+                height={100}
+              />
+            </Box>
+            <Box sx={{ textAlign: "left" }}> 
+              <Typography component="p" variant="body1" sx={{ color: "black" }}>
+                Pelletier Construction Group is dedicated to fine craftsmanship
+                and serving its customers. We provide a wide range of high quality
+                services in a professional and timely manner. Our goal is to
+                satisfy each customer and their specific construction needs for
+                ADUs, remodels, new shops, garages, decks and patio covers. If
+                your home no longer meets your needs, you don’t have to sell it
+                and move. Instead, choose a full house interior remodel. In doing
+                so, you can put your personal touch on every area of your home.
+                With a full house interior remodel, you’ll be able to customize
+                your home to ensure it aligns with your unique lifestyle and
+                preferences. If you’d like the home of your dreams without the
+                stress and expense of moving, this is an excellent option.
+              </Typography>
+            </Box>
+          </Box>
         <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
           <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>
             Get in Touch


### PR DESCRIPTION
This is a pull request!

Resolves #42 
Restores "About" page with text and logo image from previous PCG repo to current one.
Previous "About" page was HTML, current is TypeScript.

Remember to:
Add reviewers, assignees and labels in the menu on the right. --->
Enable auto-merge (squash) at the bottom of the page.