### PR TITLE
Refactor: make Google Forms responsive with reusable component

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import Image from 'next/image';
 import { Oswald } from "next/font/google";
 const oswald = Oswald({ subsets: ["latin"] });
-
+import ResponsiveFormEmbed from "@/components/ResponsiveFormEmbed";
 
 export default function Home() {
 
@@ -85,14 +85,7 @@ export default function Home() {
               </Typography>
             </Box>
           </Box>
-        <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
-          <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>
-            Get in Touch
-          </Typography>
-          <iframe
-            src="https://docs.google.com/forms/d/e/1FAIpQLSelwJL2BR_yNzPqrdGUy_s5CZFI6mNpHTv4LQ0IxRYpjwvUVQ/viewform?embedded=true"
-            width="700" height="1300">Loading…</iframe>
-        </Box>
+        <ResponsiveFormEmbed title="Get in Touch" />
       </Box>
     </Stack>    
     <Footer />

--- a/app/blueprint/page.tsx
+++ b/app/blueprint/page.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack, Typography } from "@mui/material";
 import Footer from "@/components/Footer";
+import ResponsiveFormEmbed from "@/components/ResponsiveFormEmbed";
 
 export default function Blueprint() {
   return (
@@ -12,21 +13,10 @@ export default function Blueprint() {
         </Box>
 
         {/* Google Form Embed */}
-        <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
-          <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>
-            Submit Your Blueprint Request
-          </Typography>
-          <iframe
-            title="Blueprint Builder Form"
-            src="https://docs.google.com/forms/d/e/1FAIpQLSeZW7-rxC12QP1ksxE6IvnW3zUVM4uoPT-hWWRHcgm0jbvr0Q/viewform?embedded=true"
-            width={640}
-            height={1000}
-            frameBorder={0}
-            marginHeight={0}
-            marginWidth={0}>
-            Loading…
-          </iframe>
-        </Box>
+        <ResponsiveFormEmbed
+          title="Submit Your Blueprint Request"
+          formUrl="https://docs.google.com/forms/d/e/1FAIpQLSeZW7-rxC12QP1ksxE6IvnW3zUVM4uoPT-hWWRHcgm0jbvr0Q/viewform?embedded=true"
+        />
       </Stack>    
       <Footer />
     </Box>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -3,6 +3,7 @@ import Footer from "@/components/Footer";
 import Image from "next/image";
 // i think the banner photo is a little bit bigger and it should be replaced once we get the actual photo
 import image from "@/public/images/projects/great-wall-of-lake-city/2.jpeg";
+import ResponsiveFormEmbed from "@/components/ResponsiveFormEmbed";
 
 export default function Home() {
   return (
@@ -76,29 +77,8 @@ export default function Home() {
           justifyContent={"center"}
           sx={{ width: "100%", paddingTop: "120px", backgroundColor: "white" }}
         >
-
-          <Box
-            margin="auto"
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              width: "100%",
-              backgroundColor: "rgba(54,54,54,1)",
-            }}
-          >
-            <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>
-              Get in Touch
-            </Typography>
-            <iframe
-              src="https://docs.google.com/forms/d/e/1FAIpQLSelwJL2BR_yNzPqrdGUy_s5CZFI6mNpHTv4LQ0IxRYpjwvUVQ/viewform?embedded=true"
-              width="700"
-              height="1300"
-            >
-              Loading…
-            </iframe>
+          <ResponsiveFormEmbed title="Get in Touch" />
           </Box>
-        </Box>
       </Stack>
       <Footer />
     </Box>

--- a/app/estimates/page.tsx
+++ b/app/estimates/page.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Stack, Typography } from "@mui/material";
 import Footer from "@/components/Footer";
 import Hero from "@/components/Hero";
 import Link from "next/link";
+import ResponsiveFormEmbed from "@/components/ResponsiveFormEmbed";
 
 export default function Home() {
   const heroText = "Request an Estimate!";
@@ -33,32 +34,7 @@ export default function Home() {
           <Typography component="h1" variant="h4" sx={{ pb: 4 }}>
             Estimates
           </Typography>
-          <Box
-            margin="auto"
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              width: "100%",
-              backgroundColor: "rgba(54,54,54,1)",
-            }}
-          >
-            <Typography
-              component="h1"
-              variant="h4"
-              sx={{ pb: 4, pt: 4, color: "white" }}
-            >
-              Get in Touch
-            </Typography>
-            <iframe
-              src="https://docs.google.com/forms/d/e/1FAIpQLSelwJL2BR_yNzPqrdGUy_s5CZFI6mNpHTv4LQ0IxRYpjwvUVQ/viewform?embedded=true"
-              width="700"
-              height="1300"
-              title="Estimates Form"
-            >
-              Loading…
-            </iframe>
-          </Box>
+          <ResponsiveFormEmbed title="Get in Touch" />
         </Box>
       </Stack>
       <Footer />

--- a/app/projects-page/page.tsx
+++ b/app/projects-page/page.tsx
@@ -7,7 +7,8 @@ import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
 import { redirect } from "next/navigation";
 import { useRouter } from "next/navigation";
-
+//newly added
+import ResponsiveFormEmbed from "@/components/ResponsiveFormEmbed";
 export default function Home() {
   const router = useRouter()
 
@@ -46,14 +47,7 @@ export default function Home() {
         </ImageListItem>
       ))}
       </ImageList>
-        <Box margin="auto" sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%", backgroundColor: "rgba(54,54,54,1)" }}>
-          <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>
-            Get in Touch
-          </Typography>
-          <iframe
-            src="https://docs.google.com/forms/d/e/1FAIpQLSelwJL2BR_yNzPqrdGUy_s5CZFI6mNpHTv4LQ0IxRYpjwvUVQ/viewform?embedded=true"
-            width="700" height="1300">Loading…</iframe>
-        </Box>
+        <ResponsiveFormEmbed title="Get in Touch" />
       </Box>
     </Stack>    
     <Footer />

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import image from "@/public/images/familys-historic-home.jpg";
 import Carousel from "@/components/Carousel";
 import Link from "next/link";
+import ResponsiveFormEmbed from "@/components/ResponsiveFormEmbed";
 
 //Carousel prop configuration
 const timer = 50; // number of second before the carousel changes
@@ -200,32 +201,7 @@ export default function Home() {
             visibility={starsVisibility}
             timer={timer}
           />
-          ;
-          <Box
-            margin="auto"
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              width: "100%",
-              backgroundColor: "rgba(54,54,54,1)",
-            }}
-          >
-            <Typography
-              component="h1"
-              variant="h4"
-              sx={{ pb: 4, pt: 4, color: "white" }}
-            >
-              Get in Touch
-            </Typography>
-            <iframe
-              src="https://docs.google.com/forms/d/e/1FAIpQLSelwJL2BR_yNzPqrdGUy_s5CZFI6mNpHTv4LQ0IxRYpjwvUVQ/viewform?embedded=true"
-              width="700"
-              height="1300"
-            >
-              Loading…
-            </iframe>
-          </Box>
+          <ResponsiveFormEmbed title="Get in Touch" />
         </Box>
       </Stack>
       <Footer />

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Box, Typography, Fade, Button } from "@mui/material";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
@@ -14,7 +14,8 @@ const Carousel: React.FC<CarouselProps> = ({ slides, visibility, timer }) => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
   const [fade, setFade] = useState<boolean>(true);
 
-  const showSlide = (n: number) => {
+  const showSlide = useCallback(
+    (n: number) => {
     setFade(false);
     setTimeout(() => {
       setSlideIndex(
@@ -22,7 +23,9 @@ const Carousel: React.FC<CarouselProps> = ({ slides, visibility, timer }) => {
       );
       setFade(true);
     }, 0);
-  };
+  },
+  [slides.length]
+);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -30,7 +33,7 @@ const Carousel: React.FC<CarouselProps> = ({ slides, visibility, timer }) => {
     }, timer * 1000);
 
     return () => clearInterval(interval);
-  }, [slides.length]);
+  }, [showSlide, timer]);
 
   return (
     <Box

--- a/components/ResponsiveFormEmbed.tsx
+++ b/components/ResponsiveFormEmbed.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { Box, Typography } from "@mui/material";
+
+type ResponsiveFormEmbedProps = {
+  title: string;
+  formUrl?: string;
+};
+
+export default function ResponsiveFormEmbed({
+  title,
+  formUrl = "https://docs.google.com/forms/d/e/1FAIpQLSelwJL2BR_yNzPqrdGUy_s5CZFI6mNpHTv4LQ0IxRYpjwvUVQ/viewform?embedded=true",
+}: ResponsiveFormEmbedProps) {
+  return (
+    <Box
+      margin="auto"
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        width: "100%",
+        backgroundColor: "rgba(54,54,54,1)",
+        px: 2,
+      }}
+    >
+      <Typography component="h1" variant="h4" sx={{ pb: 4, pt: 4, color: "white" }}>
+        {title}
+      </Typography>
+      <Box
+        sx={{
+          position: "relative",
+          width: "100%",
+          maxWidth: 700,
+          paddingTop: "130%", // maintains aspect ratio for responsiveness
+        }}
+      >
+        <iframe
+          src={formUrl}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            border: "none",
+          }}
+          allowFullScreen
+        />
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Resolves 
- Issue #108 

This pull request refactors the way Google Forms are embedded across the site to improve responsiveness and code maintainability.

⛔ **NOTE:** This PR only addresses the **Google Form** across the pages listed below. **Does not fix layout bugs!**

## What was implemented
- Added a new reusable component: ResponsiveFormEmbed
- Replaced static iframe blocks on the following pages: 
    - projects
    - estimates
    - about
    - testimonials
    - contact
    - blueprint
- Added support for an optional formUrl prop to handle unique form sources
- Refactored Carousel.tsx to wrap showSlide in useCallback to fix a useEffect dependency warning

---
## Expected Behavior

- Embedded Google Forms should scale responsively across all screen sizes (mobile, tablet, desktop)
- No horizontal overflow or cutoff issues
- Form layout should remain centered and readable regardless of device width
- The same styling and behavior should be consistent across all 6 pages
- Linting passes with no warnings
- The site builds successfully with npm run build

---
## Demo
**Before**

https://github.com/user-attachments/assets/a33040d7-eced-4ae5-af68-bddcfd892521

**After Fix**

https://github.com/user-attachments/assets/afad4299-efbf-4eff-971e-9c52e1efc9cf


