### PR TITLE
pelletier-construction-group-nextjs_sprint#24_issue#120_change-adu-placeholder-image

### DIFF
--- a/app/dadu/dadus.json
+++ b/app/dadu/dadus.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "CAST Architecture-1",
-        "img": "/images/index/timber_frame_barn.jpg",
+        "img": "/images/dadus/cast_architecture/PreApprovedDADU_CAST1.jpg",
         "description": "At only 467 square feet of interior floor area, the Cedar Cottage is an extremely efficient footprint that provides well daylit space for living, necessary storage, flexibility on many sites, including sloped ones, covered outdoor porch space plus easy expandability for families or roommates as a two-bedroom model.",
         "sqft": "467",
         "bed": "1-2",
@@ -39,7 +39,7 @@
       },
       {
         "name": "CAST Architecture-2",
-        "img": "/images/index/timber_frame_barn.jpg",
+        "img": "/images/dadus/cast_architecture/PreApprovedDADU_CAST1.jpg",
         "description": "At only 467 square feet of interior floor area, the Cedar Cottage is an extremely efficient footprint that provides well daylit space for living, necessary storage, flexibility on many sites, including sloped ones, covered outdoor porch space plus easy expandability for families or roommates as a two-bedroom model.",
         "sqft": "467",
         "bed": "1-2",
@@ -77,7 +77,7 @@
       },
       {
         "name": "CAST Architecture-3",
-        "img": "/images/index/timber_frame_barn.jpg",
+        "img": "/images/dadus/cast_architecture/PreApprovedDADU_CAST1.jpg",
         "description": "At only 467 square feet of interior floor area, the Cedar Cottage is an extremely efficient footprint that provides well daylit space for living, necessary storage, flexibility on many sites, including sloped ones, covered outdoor porch space plus easy expandability for families or roommates as a two-bedroom model.",
         "sqft": "467",
         "bed": "1-2",


### PR DESCRIPTION

Resolves issue #120 

I changed the placeholder image for the cards so display as the Cedar Cottage. 

To replicate:
   - Clone repo to local environment and checkout my branch
   - Navigate to /dadu and take a look at the new cards' placeholder images

Screenshot:

![Screenshot_20250609_180709](https://github.com/user-attachments/assets/8375694e-08da-45e0-8ad3-d66ecd84faa3)
