### PR TITLE
pelletier-construction-group-nextjs_sprint#24_issue#122_remove-blueprint-builder-nav-item

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -21,7 +21,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 const drawerWidth = 240;
 
 // Updated navItems array to include Blueprint Builder
-const navItems = ["HOME", "PROJECTS", "ESTIMATES", "ABOUT", "TESTIMONIALS", "CONTACT", "BLUEPRINT BUILDER", "DADU/ADU"];
+const navItems = ["HOME", "PROJECTS", "ESTIMATES", "ABOUT", "TESTIMONIALS", "CONTACT", "DADU/ADU"];
 
 // Updated links array to include the path for the Blueprint Builder page
 const links = ["/", "/projects-page", "/estimates", "/about", "/testimonials", "/contact", "/blueprint", "/dadu"];


### PR DESCRIPTION

Resolves issue #122 

I went ahead and removed the Blueprint Builder nav item, as it was replicating the estimates page.

To reproduce:
   - Clone repo to local environment and checkout my branch
   - Run npm install and npm run dev to start application
   - When in the homepage checkout the navbar

Screenshot:
![Screenshot_20250609_183025](https://github.com/user-attachments/assets/d7b09e50-1e02-428b-93f5-3163e87d4c81)

